### PR TITLE
upgrade plugin to work with latest version of dolt

### DIFF
--- a/kedro_dolt/hook.py
+++ b/kedro_dolt/hook.py
@@ -77,8 +77,12 @@ class DoltHook:
         res = None
         with self.connection() as connection:
             with connection.cursor() as cursor:
+                cursor.execute("select active_branch()")
                 cursor.execute("select * from dolt_status")
                 status = cursor.fetchone()
+            connection.commit()
+        with self.connection() as connection:
+            with connection.cursor() as cursor:
                 if status is not None:
                     cursor.execute(f"select dolt_commit('-am', '{message}') as c")
                     res = cursor.fetchone()["c"]
@@ -104,6 +108,7 @@ class DoltHook:
                     cursor.execute(f"select dolt_checkout('-b', '{branch}')")
                 else:
                     cursor.execute(f"select dolt_checkout('{branch}')")
+                cursor.execute(f"set global dolt_sql_server_branch_ref = 'refs/heads/{branch}'")
             connection.commit()
 
     @hook_impl

--- a/kedro_dolt/hook.py
+++ b/kedro_dolt/hook.py
@@ -77,12 +77,8 @@ class DoltHook:
         res = None
         with self.connection() as connection:
             with connection.cursor() as cursor:
-                cursor.execute("select active_branch()")
                 cursor.execute("select * from dolt_status")
                 status = cursor.fetchone()
-            connection.commit()
-        with self.connection() as connection:
-            with connection.cursor() as cursor:
                 if status is not None:
                     cursor.execute(f"select dolt_commit('-am', '{message}') as c")
                     res = cursor.fetchone()["c"]

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -144,9 +144,6 @@ def test_after_pipeline_run_checkout(hook, conn, config):
         hook.after_pipeline_run(run_params=dict(run_id="f"))
 
         compare_active_branch(config, br)
-        #conn.execute("select active_branch() as b")
-        #res = conn.fetchone()["b"]
-        #assert res == br
 
 
 def test_after_pipeline_run_commit(hook, conn, config):
@@ -178,9 +175,6 @@ def test_e2e_pipeline_run_commit(hook, conn, config):
 
     hook.before_pipeline_run(dict(extra_params=dict(branch=workflow_branch)))
     compare_active_branch(config, workflow_branch)
-    #conn.execute("select active_branch() as b")
-    #mid_branch = conn.fetchone()["b"]
-    #assert mid_branch == workflow_branch
     assert hook._original_branch == starting_branch
 
     with new_connection(config) as conn:


### PR DESCRIPTION
the introduction of transaction concurrency broke this plugin's plugins about shared branch state. Now there is a global variable to change the default branch for new connections.